### PR TITLE
chore: remove 'congrats' on start)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,4 +5,4 @@ import handlers
 from handlers.a1_say_hello import congrats
 
 if __name__ == "__main__":
-    executor.start_polling(dp, skip_updates=True, on_startup=congrats)
+    executor.start_polling(dp, skip_updates=True)


### PR DESCRIPTION
Удалил поздравление при запуске. Тк у нас стоит рестарт бота при ошибках(в docker-compose.yml), то при старте всем отправляется повторное поздравление. На сервере сделал такой же фикс. Но после мерджа лучше обновить на сервер, чтоб не было потом конфликтов.